### PR TITLE
Add settings for pathfinder 1e

### DIFF
--- a/scripts/systems.js
+++ b/scripts/systems.js
@@ -201,6 +201,48 @@ export function defaultAttributesConfig() {
                 units: "Spell DC",
             },
         ],
+        pf1: [
+            {
+                attr: "attributes.hp.value",
+                icon: "fas fa-heart",
+                units: "HP",
+            },
+            {
+                attr: "attributes.ac.normal.total",
+                icon: "fas fa-shield",
+                units: "AC",
+            },
+            {
+                attr: "attributes.ac.touch.total",
+                icon: "fas fa-shield-slash",
+                units: "Touch AC",
+            },
+            {
+                attr: "attributes.ac.flatFooted.total",
+                icon: "fas fa-circle-exclamation",
+                units: "Flat Footed AC",
+            },
+            {
+                attr: "attributes.cmd.total",
+                icon: "fas fa-hand-fist",
+                units: "CMD",
+            },
+            {
+                attr: "attributes.cmd.flatFootedTotal",
+                icon: "fas fa-person-circle-exclamation",
+                units: "Flat Footed CMD",
+            },
+            {
+                attr: "attributes.sr.total",
+                icon: "fas fa-hand-holding-magic",
+                units: "Spell Resistance",
+            },
+            {
+                attr: "attributes.speed.land.total",
+                icon: "fas fa-person-running",
+                units: "ft.",
+            },
+        ],
         crucible: [
             {
                 "attr": "resources.health.value",


### PR DESCRIPTION
Add support for Pathfinder 1E system.

This PR includes height attributes:
- HP
- AC
- Touch AC
- Flat Footed AC
- CMD
- Flat Footed CMD
- Spell Resistance
- Speed (in feet)

Here are some screenshots proving a test (units are to be ignored, they are in English in the PR):
![image](https://github.com/theripper93/combat-tracker-dock/assets/15614283/890145b1-e275-4d8a-84da-be63f5d2d550)

I tried to use a logic similar to other systems for attributes, meaning values that are related to defense and need to be often used during a fight (such as AC). There are lots of other defensive values, such as immunities, weakness or resistance, but I believe it would be too much.