### PR TITLE
System support for Exalted 3rd Edition

### DIFF
--- a/scripts/systems.js
+++ b/scripts/systems.js
@@ -339,6 +339,43 @@ export function defaultAttributesConfig() {
                 units: game.i18n.localize("ALIENRPG.ArmorRating"),
             },
         ],
+        exaltedthird: [
+            {
+                attr: "health.value",
+                icon: "fas fa-heart",
+                units: game.i18n.localize("Ex3.Health"),
+            },
+            {
+                attr: "evasion.value",
+                icon: "fas fa-rabbit-running",
+                units: game.i18n.localize("Ex3.Evasion"),
+            },
+            {
+                attr: "parry.value",
+                icon: "fas fa-swords",
+                units: game.i18n.localize("Ex3.Parry"),
+            },
+            {
+                attr: "soak.value",
+                icon: "fas fa-shield",
+                units: game.i18n.localize("Ex3.Soak"),
+            },
+            {
+                attr: "hardness.value",
+                icon: "fas fa-heart",
+                units: game.i18n.localize("Ex3.Hardness"),
+            },
+            {
+                attr: "willpower.value",
+                icon: "fas fa-hand-fist",
+                units: game.i18n.localize("Ex3.Willpower"),
+            },
+            {
+                attr: "anima.value",
+                icon: "fas fa-sun",
+                units: game.i18n.localize("Ex3.Anima"),
+            },
+        ],
     };
 }
 
@@ -514,6 +551,14 @@ export function generateDescription(actor) {
                 default:
                     return null;
             }
+        case "exaltedthird":
+            switch (type) {
+                case "character":
+                case "npc":
+                    return `${game.i18n.localize("Ex3.Essence")} ${system.essence.value}`
+                default:
+                    return null;
+            }
     }
 }
 
@@ -559,7 +604,14 @@ export function getInitiativeDisplay(combatant) {
                 rollIcon: "fa-solid fa-cards-blank",
             };
 	}
-        default:
+    case "exaltedthird": {
+        return {
+            value: combatant?.initiative,
+            icon: "far fa-dice-d10",
+            rollIcon: "far fa-dice-d10",
+        };
+    }
+    default:
             return {
                 value: combatant?.initiative,
                 icon: "far fa-dice-d20",


### PR DESCRIPTION
Includes the following attributes:

- Health
- Evasion
- Parry
- Soak
- Hardness
- Willpower
- Anima

Essence level is displayed below the character's name.

Instead of d20, a d10 is used to represent the initiative roll.

![Ex3_attributes](https://github.com/theripper93/combat-tracker-dock/assets/22562624/2c2f8f62-cb99-4e4b-ab40-7bdf231b0b67)
