### PR TITLE
Adds High Contrast Mode setting

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -95,6 +95,10 @@
                 "name": "Show Initiative on Portrait",
                 "hint": "Show the initiative value in the top left corner of the portrait. You can always see the initiative in the Tooltip!"
             },
+            "highContrast": {
+                "name": "Use High Contrast on Portrait",
+                "hint": "Use high contrast UI features on combatant portraits. This can improve readability for certain types of portrait art, such as black and white."
+            },
             "portraitImageBorder": {
                 "name": "Player Border",
                 "hint": "Special border that will be shown for player characters. Leave blank to disable. If you wish to make a custom image, it's suggested you use the default one as reference for correct sizing."

--- a/scripts/App/CombatantPortrait.js
+++ b/scripts/App/CombatantPortrait.js
@@ -304,6 +304,7 @@ export class CombatantPortrait {
             hasPlayerOwner: combatant.actor?.hasPlayerOwner,
             hasPermission: hasPermission,
             showInitiative: game.settings.get(MODULE_ID, "showInitiativeOnPortrait"),
+            highContrast: game.settings.get(MODULE_ID, "highContrast"),
             isInitiativeNaN: combatant.initiative === null || combatant.initiative === undefined,
             initiativeData: initiativeData,
             resource: resource,

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -303,6 +303,16 @@ export function registerSettings() {
         onChange: () => ui.combatDock?.refresh(),
     });
 
+    game.settings.register(MODULE_ID, "highContrast", {
+        name: "combat-tracker-dock.settings.highContrast.name",
+        hint: "combat-tracker-dock.settings.highContrast.hint",
+        scope: "world",
+        config: true,
+        type: Boolean,
+        default: false,
+        onChange: () => ui.combatDock?.refresh(),
+    });    
+
     game.settings.register(MODULE_ID, "portraitImage", {
         name: "combat-tracker-dock.settings.portraitImage.name",
         hint: "combat-tracker-dock.settings.portraitImage.hint",

--- a/scss/_portrait.scss
+++ b/scss/_portrait.scss
@@ -1,4 +1,44 @@
 #combat-dock {
+
+    & .high-contrast {
+
+        &:hover,
+        &.hovered {
+           & div.combatant-buttons {
+                 opacity: 1;
+                 text-shadow: 0px 0px 3px black;
+           }
+       }
+    
+       & i.roll-initiative {
+           opacity: 1;
+           text-shadow: 0px 0px 5px black;
+           font-weight: 300;
+       }
+
+       & div.portrait-initiative{
+            opacity: 1;
+            & i {
+                color:black;
+            }
+       }
+
+       & div.portrait-pass{
+            & i {
+                text-shadow: 0px 0px 5px black;
+            }
+        }
+       
+       & .tracked-attribute-text-container {
+           background: rgb(0,0,0,0.75);
+       }
+       
+       & .tracked-attribute-bar-max {
+           z-index:1;
+       }
+       
+    }
+
     & .combatant-portrait {
         pointer-events: all;
         width: var(--combatant-portrait-size);
@@ -29,7 +69,7 @@
         }
 
         &.visible {
-            opacity: 0.5;
+            opacity: 1;
         }
 
         //define border blink animation
@@ -358,3 +398,6 @@
         }
     }
 }
+
+
+   

--- a/templates/combatant-portrait.hbs
+++ b/templates/combatant-portrait.hbs
@@ -1,4 +1,4 @@
-<div class="combatant-wrapper" style="background-image: url('{{img}}');{{#if defeated}}filter: grayscale(1);{{/if}}">
+<div class="combatant-wrapper{{#if highContrast}} high-contrast{{/if}}" style="background-image: url('{{img}}');{{#if defeated}}filter: grayscale(1);{{/if}}">
 
     {{#if hasPortraitResource}}
     <div class="portrait-bar" style="height: calc( 100% - {{portraitResource.percentage}}% );"></div>


### PR DESCRIPTION
ShadowDark RPG and other OSR  game systems tend to use a lot of black and white images for things like character or monster profiles. It's almost impossible to see the text and icons when using Carousel Combat Tracker with black and white profiles. This PR proposed the introduction of a High Contrast Mode setting that provide alternative CSS styling in order to improving readability. 

[Example]
Default state:
![before](https://github.com/theripper93/combat-tracker-dock/assets/147362581/660fbcf1-c855-410e-99cf-2ccc703feac5)

With setting on
![after](https://github.com/theripper93/combat-tracker-dock/assets/147362581/8be7c760-b4c0-44ef-a83e-70556b44930e)
