### PR TITLE
Added support for masking hover events on token and combatants when selected token doesn't have vision per Vision 5e module

### DIFF
--- a/scripts/App/CombatantPortrait.js
+++ b/scripts/App/CombatantPortrait.js
@@ -1,6 +1,6 @@
 import { MODULE_ID } from "../main.js";
 import { generateDescription, getInitiativeDisplay, getSystemIcons } from "../systems.js";
-import { DETECTION_LEVELS } from "../const.js";
+import { VISION5E_DETECTION_LEVELS } from "../const.js";
 
 export class CombatantPortrait {
     constructor(combatant) {
@@ -146,7 +146,7 @@ export class CombatantPortrait {
 
      _onHoverIn(event) {
         if (!this.token) return;
-        const tokenHasVision = !this.token?.detectionLevel || this.token?.detectionLevel === DETECTION_LEVELS.PRECISE;
+        const tokenHasVision = !this.token?.detectionLevel || this.token?.detectionLevel === VISION5E_DETECTION_LEVELS.PRECISE;
         if ( this.token?.isVisible && !this.token.controlled && tokenHasVision ) this.token._onHoverIn(event);
     }
 

--- a/scripts/App/CombatantPortrait.js
+++ b/scripts/App/CombatantPortrait.js
@@ -1,5 +1,6 @@
 import { MODULE_ID } from "../main.js";
 import { generateDescription, getInitiativeDisplay, getSystemIcons } from "../systems.js";
+import { DETECTION_LEVELS } from "../const.js";
 
 export class CombatantPortrait {
     constructor(combatant) {
@@ -143,9 +144,10 @@ export class CombatantPortrait {
         }
     }
 
-    _onHoverIn(event) {
+     _onHoverIn(event) {
         if (!this.token) return;
-        if ( this.token?.isVisible && !this.token.controlled ) this.token._onHoverIn(event);
+        const tokenHasVision = !this.token?.detectionLevel || this.token?.detectionLevel === DETECTION_LEVELS.PRECISE;
+        if ( this.token?.isVisible && !this.token.controlled && tokenHasVision ) this.token._onHoverIn(event);
     }
 
     _onHoverOut(event) {

--- a/scripts/App/CombatantPortrait.js
+++ b/scripts/App/CombatantPortrait.js
@@ -146,6 +146,7 @@ export class CombatantPortrait {
 
      _onHoverIn(event) {
         if (!this.token) return;
+        // tokenHasVision is derived from Vision5e module 
         const tokenHasVision = !this.token?.detectionLevel || this.token?.detectionLevel === VISION5E_DETECTION_LEVELS.PRECISE;
         if ( this.token?.isVisible && !this.token.controlled && tokenHasVision ) this.token._onHoverIn(event);
     }

--- a/scripts/App/Tracker.js
+++ b/scripts/App/Tracker.js
@@ -1,5 +1,6 @@
 import { MODULE_ID } from "../main.js";
 import { AddEvent } from "./AddEvent.js";
+import { DETECTION_LEVELS } from "../const.js";
 
 export class CombatDock extends Application {
     constructor(combat) {
@@ -499,7 +500,8 @@ export class CombatDock extends Application {
 
     _onHoverToken(token, hover) {
         const portrait = this.portraits.find((p) => p.token === token);
-        if (!portrait) return;
+        const tokenHasVision = !token.detectionLevel || token.detectionLevel === DETECTION_LEVELS.PRECISE;
+        if (!portrait || !tokenHasVision) return;
         portrait.element.classList.toggle("hovered", hover);
     }
 

--- a/scripts/App/Tracker.js
+++ b/scripts/App/Tracker.js
@@ -500,6 +500,7 @@ export class CombatDock extends Application {
 
     _onHoverToken(token, hover) {
         const portrait = this.portraits.find((p) => p.token === token);
+        // tokenHasVision is derived from Vision5e module 
         const tokenHasVision = !token.detectionLevel || token.detectionLevel === VISION5E_DETECTION_LEVELS.PRECISE;
         if (!portrait || !tokenHasVision) return;
         portrait.element.classList.toggle("hovered", hover);

--- a/scripts/App/Tracker.js
+++ b/scripts/App/Tracker.js
@@ -1,6 +1,6 @@
 import { MODULE_ID } from "../main.js";
 import { AddEvent } from "./AddEvent.js";
-import { DETECTION_LEVELS } from "../const.js";
+import { VISION5E_DETECTION_LEVELS } from "../const.js";
 
 export class CombatDock extends Application {
     constructor(combat) {
@@ -500,7 +500,7 @@ export class CombatDock extends Application {
 
     _onHoverToken(token, hover) {
         const portrait = this.portraits.find((p) => p.token === token);
-        const tokenHasVision = !token.detectionLevel || token.detectionLevel === DETECTION_LEVELS.PRECISE;
+        const tokenHasVision = !token.detectionLevel || token.detectionLevel === VISION5E_DETECTION_LEVELS.PRECISE;
         if (!portrait || !tokenHasVision) return;
         portrait.element.classList.toggle("hovered", hover);
     }

--- a/scripts/const.js
+++ b/scripts/const.js
@@ -1,4 +1,4 @@
-export const DETECTION_LEVELS = Object.freeze({
+export const VISION5E_DETECTION_LEVELS = Object.freeze({
     NONE: 0,
     IMPRECISE: 1,
     PRECISE: 2,

--- a/scripts/const.js
+++ b/scripts/const.js
@@ -1,0 +1,5 @@
+export const DETECTION_LEVELS = Object.freeze({
+    NONE: 0,
+    IMPRECISE: 1,
+    PRECISE: 2,
+});


### PR DESCRIPTION
Vision 5e is a module that provides advanced visibility options and automatically manages the token's Detection methods.  It includes functionality that restricts highlighting the token when you hover over the combatant on the Combat Tracker and vice versa, when the selected token can't clearly see the token due to lighting or vision constraints.  To preserve the immersion that you can't see, but you can hear someone nearby and don't know who it is.

My PR copies some of that detection methodology to your combatants' onhover as well as the token onhover events so we can maintain the immersion when using Combat Carousel Tracker.

If you have any feedback feel free to reach out.  I hope you accept my work.